### PR TITLE
Add terraform provider for reading A, TXT, and CNAME records.

### DIFF
--- a/dns/provider.go
+++ b/dns/provider.go
@@ -1,0 +1,18 @@
+package dns
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"dns_a_record":     resourceDnsARecord(),
+			"dns_cname_record": resourceDnsCnameRecord(),
+			"dns_txt_record":   resourceDnsTxtRecord(),
+		},
+	}
+}

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -1,0 +1,28 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"dns": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}

--- a/dns/resource_dns_a_record.go
+++ b/dns/resource_dns_a_record.go
@@ -1,0 +1,53 @@
+package dns
+
+import (
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDnsARecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDnsARecordCreate,
+		Update: resourceDnsARecordUpdate,
+		Read:   resourceDnsARecordRead,
+		Delete: resourceDnsARecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"addrs": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDnsARecordCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("name").(string))
+	return resourceDnsARecordRead(d, meta)
+}
+
+func resourceDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
+	addrs, err := net.LookupHost(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("addrs", addrs)
+	return nil
+}
+
+func resourceDnsARecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceDnsARecordRead(d, meta)
+}
+
+func resourceDnsARecordDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -1,0 +1,52 @@
+package dns
+
+import (
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDnsCnameRecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDnsCnameRecordCreate,
+		Update: resourceDnsCnameRecordUpdate,
+		Read:   resourceDnsCnameRecordRead,
+		Delete: resourceDnsCnameRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"cname": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDnsCnameRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("name").(string))
+	return resourceDnsCnameRecordRead(d, meta)
+}
+
+func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error {
+	cname, err := net.LookupCNAME(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("cname", cname)
+	return nil
+}
+
+func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceDnsCnameRecordRead(d, meta)
+}
+
+func resourceDnsCnameRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/dns/resource_dns_txt_record.go
+++ b/dns/resource_dns_txt_record.go
@@ -1,0 +1,68 @@
+package dns
+
+import (
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDnsTxtRecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDnsTxtRecordCreate,
+		Update: resourceDnsTxtRecordUpdate,
+		Read:   resourceDnsTxtRecordRead,
+		Delete: resourceDnsTxtRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"update": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"records": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDnsTxtRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("name").(string))
+	records, err := net.LookupTXT(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("records", records)
+	return nil
+}
+
+func resourceDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error {
+	// Read if forcing an update, or we haven't yet read any records
+	if d.Get("update").(bool) {
+		records, err := net.LookupTXT(d.Id())
+		if err != nil {
+			return err
+		}
+
+		d.Set("records", records)
+	}
+	return nil
+}
+
+func resourceDnsTxtRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceDnsTxtRecordRead(d, meta)
+}
+
+func resourceDnsTxtRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/plugin"
+
+	"github.com/Shopify/terraform-provider-dns/dns"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: dns.Provider,
+	})
+}


### PR DESCRIPTION
The TXT record has a special `update` attribute which (when false) prevents updating the resource's state with any new/updated records.

@Shopify/cloud 
