### PR TITLE
Remove superfluous update functions.

### DIFF
--- a/dns/resource_dns_a_record.go
+++ b/dns/resource_dns_a_record.go
@@ -9,7 +9,6 @@ import (
 func resourceDnsARecord() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDnsARecordCreate,
-		Update: resourceDnsARecordUpdate,
 		Read:   resourceDnsARecordRead,
 		Delete: resourceDnsARecordDelete,
 
@@ -42,10 +41,6 @@ func resourceDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("addrs", addrs)
 	return nil
-}
-
-func resourceDnsARecordUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceDnsARecordRead(d, meta)
 }
 
 func resourceDnsARecordDelete(d *schema.ResourceData, meta interface{}) error {

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -9,7 +9,6 @@ import (
 func resourceDnsCnameRecord() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDnsCnameRecordCreate,
-		Update: resourceDnsCnameRecordUpdate,
 		Read:   resourceDnsCnameRecordRead,
 		Delete: resourceDnsCnameRecordDelete,
 
@@ -41,10 +40,6 @@ func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	d.Set("cname", cname)
 	return nil
-}
-
-func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceDnsCnameRecordRead(d, meta)
 }
 
 func resourceDnsCnameRecordDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
I found that the new terraform will validate schemas themselves, and it complains about superfluous update funcs. These two resources have superfluous updates because all of the attributes are either `ForceNew = true` or `Computed = true`, without any being optional. This means that the update func will never be called.

Tested before and after this change and with it the schema validation errors go away.

@Shopify/cloud 